### PR TITLE
Support for using core-api for verifying User Roles and using FABRIC user ID as username

### DIFF
--- a/jupyterhub-k8s/config.gke.yaml
+++ b/jupyterhub-k8s/config.gke.yaml
@@ -21,16 +21,16 @@ singleuser:
     guarantee: 512M
   image: 
     name: fabrictestbed/jupyter-notebook
-    tag: 1.3.0
+    tag: 1.5.0
   extraEnv:
     FABRIC_CREDMGR_HOST: cm.fabric-testbed.net
     FABRIC_ORCHESTRATOR_HOST: orchestrator.fabric-testbed.net
     FABRIC_TOKEN_LOCATION: /home/fabric/.tokens.json
     FABRIC_NOTEBOOK_LOCATION: /home/fabric/work
-    FABRIC_NOTEBOOK_TAGS: rel1.3.1
+    FABRIC_NOTEBOOK_TAGS: rel1.5.0
     FABRIC_NOTEBOOK_REPO_URL: https://github.com/fabric-testbed/jupyter-examples/archive/refs/tags/
     FABRIC_CONFIG_LOCATION: /home/fabric/work/fabric_config
-    FABRIC_BASTION_HOST: bastion-1.fabric-testbed.net
+    FABRIC_BASTION_HOST: bastion.fabric-testbed.net
     FABRIC_BASTION_PRIVATE_KEY_NAME: fabric-bastion-key
     FABRIC_SLICE_PRIVATE_KEY_NAME: slice_key
     FABRIC_SLICE_PUBLIC_KEY_NAME: slice_key.pub
@@ -41,11 +41,53 @@ singleuser:
   lifecycleHooks:
     postStart:
       exec:
-          command: ["/opt/conda/bin/python3", "/var/tmp/jupyter_startup.py"]
+          command: ["/opt/conda/bin/python3.9", "/opt/conda/lib/python3.9/site-packages/jupyternb/jupyter_startup.py"]
+  profileList:
+    - display_name: "FABRIC Examples v1.4.6,  FABlib v1.4.4: released: 05/21/2023, stable: Summer 2023"
+      kubespawner_override:
+        image: fabrictestbed/jupyter-notebook:1.4.4
+        lifecycle_hooks:
+          postStart:
+            exec:
+              command:
+                - "/bin/sh"
+                - "-c"
+                - |
+                  export FABRIC_NOTEBOOK_TAGS=rel1.4.6
+                  /opt/conda/bin/python3.9 /opt/conda/lib/python3.9/site-packages/jupyternb/jupyter_startup.py
+    - display_name: "(default) FABRIC Examples v1.5.0,  FABlib v1.5.0: released: 06/12/2023, stable: Fall 2023"
+      default: true
+    - display_name: "(bleeding edge) FABRIC Examples latest, FABlib latest, Current Release"
+      kubespawner_override:
+        lifecycle_hooks:
+          postStart:
+            exec:
+              command:
+                - "/bin/sh"
+                - "-c"
+                - |
+                  export FABRIC_NOTEBOOK_TAGS=curl -s https://api.github.com/repos/fabric-testbed/jupyter-examples/releases/latest | grep '"tag_name":' | cut -d '"' -f 4
+                  /opt/conda/bin/python3.9 /opt/conda/lib/python3.9/site-packages/jupyternb/jupyter_startup.py
+                  /opt/conda/bin/pip install --ignore-installed fabrictestbed-extensions
+    - display_name: "(beyond bleeding edge) FABRIC Examples (main branch), FABlib (master branch)"
+      kubespawner_override:
+        lifecycle_hooks:
+          postStart:
+            exec:
+              command:
+                - "/bin/sh"
+                - "-c"
+                - |
+                  /opt/conda/bin/python3.9 /opt/conda/lib/python3.9/site-packages/jupyternb/jupyter_startup.py
+                  /opt/conda/bin/pip install -e git+https://github.com/fabric-testbed/fabrictestbed-extensions@main
+                  git clone https://github.com/fabric-testbed/fabrictestbed-extensions.git /home/fabric/fabrictestbed-extensions
+                  if [ ! -d "/home/fabric/work/jupyter-examples" ]; then
+                    git clone https://github.com/fabric-testbed/jupyter-examples.git /home/fabric/work/jupyter-examples
+                  fi
 hub:
   image: 
     name: fabrictestbed/jupyterhub-k8s
-    tag: 1.2.0
+    tag: 1.4.0
   config:
     Authenticator:
       admin_users:
@@ -55,7 +97,7 @@ hub:
       refresh_pre_spawn: True 
       auth_refresh_age: 86400
     JupyterHub:
-      authenticator_class: fabricauthenticator.FabricAuthenticator
+      authenticator_class: fabricauthenticator.fabricauthenticator.FabricAuthenticator
       cookie_secret: 
     CILogonOAuthenticator:
       username_claim: email

--- a/jupyterhub-k8s/config.gke.yaml
+++ b/jupyterhub-k8s/config.gke.yaml
@@ -21,13 +21,14 @@ singleuser:
     guarantee: 512M
   image: 
     name: fabrictestbed/jupyter-notebook
-    tag: 1.5.0
+    tag: 1.8.1
   extraEnv:
     FABRIC_CREDMGR_HOST: cm.fabric-testbed.net
     FABRIC_ORCHESTRATOR_HOST: orchestrator.fabric-testbed.net
+    FABRIC_CORE_API_HOST: uis.fabric-testbed.net
     FABRIC_TOKEN_LOCATION: /home/fabric/.tokens.json
     FABRIC_NOTEBOOK_LOCATION: /home/fabric/work
-    FABRIC_NOTEBOOK_TAGS: rel1.5.0
+    FABRIC_NOTEBOOK_TAGS: rel1.8.1
     FABRIC_NOTEBOOK_REPO_URL: https://github.com/fabric-testbed/jupyter-examples/archive/refs/tags/
     FABRIC_CONFIG_LOCATION: /home/fabric/work/fabric_config
     FABRIC_BASTION_HOST: bastion.fabric-testbed.net
@@ -87,20 +88,30 @@ singleuser:
 hub:
   image: 
     name: fabrictestbed/jupyterhub-k8s
-    tag: 1.4.0
+    tag: 1.9.0
+  loadRoles:
+    user: 
+      description: 'Standard user privileges'
+      scopes: ['self', 'read:metrics']
+    server: 
+      description: 'Post activity only'
+      scopes: ['users:activity!user', access:servers!user, 'read:metrics']
   config:
+    KubeSpawner:
+      slug_scheme: safe
     Authenticator:
       admin_users:
         - kthare10@email.unc.edu
         - stealey@email.unc.edu
       enable_auth_state: True
       refresh_pre_spawn: True 
-      auth_refresh_age: 86400
+      auth_refresh_age: 86400 
+      allow_all: true
     JupyterHub:
       authenticator_class: fabricauthenticator.fabricauthenticator.FabricAuthenticator
       cookie_secret: 
     CILogonOAuthenticator:
-      username_claim: email
+      username_claim: username
       client_id: 
       client_secret: 
       oauth_callback_url: https://jupyter.fabric-testbed.net/hub/oauth_callback
@@ -111,6 +122,10 @@ hub:
          "restartPolicy": "OnFailure"
       }
   extraEnv:
+    FABRIC_JUPYTERHUB_ROLE: Jupyterhub
+    FABRIC_CORE_API_HOST: "https://uis.fabric-testbed.net"
+    FABRIC_CORE_API_BEARER_TOKEN: 
+    FABRIC_PRE_SPAWN_TIMEOUT: "60"
     # see https://jupyterhub.readthedocs.io/en/stable/reference/authenticators.html#authentication-state
     # for JUPYTERHUB_CRYPT_KEY
     JUPYTERHUB_CRYPT_KEY: 


### PR DESCRIPTION
Support for using core-api for verifying User Roles and using FABRIC user ID as username

- Enables user migration across organizations/email changes without affecting PVC volume changes
- Compatible
   - Helm chart version:   4.2.0
   - JupyterHub version:   5.3.0